### PR TITLE
bugfix mod_assemelin.F90

### DIFF
--- a/mod_asselin.F90
+++ b/mod_asselin.F90
@@ -48,10 +48,12 @@
 !$OMP PARALLEL DO PRIVATE(j,i,k,ktr)
       do j=1,jj
         do i=1,ii
+          if (SEA_P) then
           oneta( i,j,n) = 1.0 + pbavg(i,j,n)/pbot(i,j)  !t-1
           oneta( i,j,m) = 1.0 + pbavg(i,j,m)/pbot(i,j)  !t
           onetao(i,j,n) = oneta( i,j,n)
           onetao(i,j,m) = oneta( i,j,m)
+          endif
         enddo !i
         do k= 1,kk
           do i=1,ii


### PR DESCRIPTION
Line ~51 division by zero on land points (pbot). Only calculate water points. Maybe this should be expanded to other parts of the routine/loop that do not divide by zero