### PR TITLE
Bug fixes

### DIFF
--- a/geopar.F90
+++ b/geopar.F90
@@ -745,8 +745,6 @@
           vtotm( i,j)=hugel
           uflux( i,j)=hugel
           vflux( i,j)=hugel
-          uflux1(i,j)=hugel
-          vflux1(i,j)=hugel
           uflux2(i,j)=hugel
           vflux2(i,j)=hugel
           uflux3(i,j)=hugel

--- a/mod_cb_arrays.F90
+++ b/mod_cb_arrays.F90
@@ -79,7 +79,6 @@
       real, save, dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy) ::  &
 #endif
        corio,          & ! coriolis parameter
-       potvor,         & ! potential vorticity
        srfhgt,         & ! sea surface height, g*ssh(m)
        steric,         & ! steric sea surface height, g*sssh(m)
        sshgmn,         & !   mean sea surface height, g*mssh(m)
@@ -138,7 +137,6 @@
        utotm, vtotm,   & ! total (barotrop.+baroclin.)..
        utotn, vtotn,   & ! ..velocities at 2 time levels
        uflux, vflux,   & ! horizontal mass fluxes
-       uflux1,vflux1,  & ! more mass fluxes
        uflux2,vflux2,  & ! more mass fluxes
        uflux3,vflux3,  & ! more mass fluxes
        onetacnt          ! 1+eta(t+1) after cnuity
@@ -1057,7 +1055,6 @@
 #if defined(RELO)
       allocate( &
               corio(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy), &
-             potvor(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy), &
              srfhgt(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy), &
              steric(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy), &
              sshgmn(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy), &
@@ -1065,10 +1062,9 @@
             montg_c(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy), &
              montg1(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy), &
                skap(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy) )
-      call mem_stat_add( 9*(idm+2*nbdy)*(jdm+2*nbdy) )
+      call mem_stat_add( 8*(idm+2*nbdy)*(jdm+2*nbdy) )
 #endif
               corio = r_init
-             potvor = r_init
              srfhgt = r_init
              steric = r_init
              sshgmn = r_init

--- a/mod_cb_arrays.F90
+++ b/mod_cb_arrays.F90
@@ -1140,14 +1140,12 @@
                vtotn(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy) , &
                uflux(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy), &
                vflux(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy), &
-              uflux1(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy), &
-              vflux1(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy), &
               uflux2(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy), &
               vflux2(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy), &
               uflux3(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy), &
               vflux3(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy), &
             onetacnt(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy) )
-      call mem_stat_add( 16*(idm+2*nbdy)*(jdm+2*nbdy) )
+      call mem_stat_add( 13*(idm+2*nbdy)*(jdm+2*nbdy) )
 #endif
                ubrhs = r_init
                vbrhs = r_init
@@ -1157,8 +1155,6 @@
                vtotn = r_init
                uflux = r_init
                vflux = r_init
-              uflux1 = r_init
-              vflux1 = r_init
               uflux2 = r_init
               vflux2 = r_init
               uflux3 = r_init

--- a/mod_cb_arrays.F90
+++ b/mod_cb_arrays.F90
@@ -134,7 +134,6 @@
 #else
       real, save, dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy) ::  &
 #endif
-       defor1,defor2,  & ! deformation components
        ubrhs, vbrhs,   & ! rhs of barotropic u,v eqns.
        utotm, vtotm,   & ! total (barotrop.+baroclin.)..
        utotn, vtotn,   & ! ..velocities at 2 time levels
@@ -1133,8 +1132,6 @@
 !
 #if defined(RELO)
       allocate( &
-              defor1(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy), &
-              defor2(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy), &
                ubrhs(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy), &
                vbrhs(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy), &
                utotm(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy), &
@@ -1150,10 +1147,8 @@
               uflux3(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy), &
               vflux3(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy), &
             onetacnt(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy) )
-      call mem_stat_add( 18*(idm+2*nbdy)*(jdm+2*nbdy) )
+      call mem_stat_add( 16*(idm+2*nbdy)*(jdm+2*nbdy) )
 #endif
-              defor1 = r_init
-              defor2 = r_init
                ubrhs = r_init
                vbrhs = r_init
                utotm = r_init

--- a/mod_hycom.F90
+++ b/mod_hycom.F90
@@ -1973,8 +1973,8 @@
 !!Alex  calculation of seas surface slope for export to CICE (NUOPC)
 !$OMP     PARALLEL DO PRIVATE(j,i) &
 !$OMP             SCHEDULE(STATIC,jblk)
-      do j=1-nbdy,jj+nbdy
-        do i=1-nbdy,ii+nbdy
+      do j=1,jj
+        do i=1,ii
           if (SEA_P) then
             ssh_e = 0.0
             ssh_w = 0.0
@@ -2022,8 +2022,8 @@
 !!Alex calculation of u and v surf for export to CICE
 !$OMP     PARALLEL DO PRIVATE(j,i) &
 !$OMP             SCHEDULE(STATIC,jblk)
-      do j=1-nbdy,jj+nbdy
-        do i=1-nbdy,ii+nbdy
+      do j=1,jj
+        do i=1,ii
           if (SEA_P) then
 ! ---       average currents over top thkcdw meters
             thksur = onem*min( thkcdw, depths(i,j) )
@@ -3701,8 +3701,8 @@
 !Alex  calculation of seas surface slope for export to CICE (NUOPC)
 !$OMP     PARALLEL DO PRIVATE(j,i) &
 !$OMP             SCHEDULE(STATIC,jblk)
-        do j=1-nbdy,jj+nbdy
-          do i=1-nbdy,ii+nbdy
+        do j=1,jj
+          do i=1,ii
           if (SEA_P) then
            ssh_e = 0.0
            ssh_w = 0.0

--- a/mod_hycom.F90
+++ b/mod_hycom.F90
@@ -1772,8 +1772,8 @@
             if (jerlv0.gt.0) then
 ! ---       calculate jerlov water type,
 ! ---       which governs the penetration depth of shortwave radiation.
-!$OMP     PARALLEL DO PRIVATE(j,i)
-!$OMP&             SCHEDULE(STATIC,jblk)
+!$OMP     PARALLEL DO PRIVATE(j,i) &
+!$OMP             SCHEDULE(STATIC,jblk)
               do j=1-nbdy,jj+nbdy
                 do i=1-nbdy,ii+nbdy
 ! ---           map shallow depths to high jerlov numbers
@@ -1785,8 +1785,8 @@
             else
 ! ---     jerlv0= 0 uses an input annual/monthly kpar field
 ! ---     jerlv0=-1 uses an input annual/monthly chl  field
-!$OMP     PARALLEL DO PRIVATE(j,i)
-!$OMP&             SCHEDULE(STATIC,jblk)
+!$OMP     PARALLEL DO PRIVATE(j,i) &
+!$OMP             SCHEDULE(STATIC,jblk)
               do j=1-nbdy,jj+nbdy
                 do i=1-nbdy,ii+nbdy
                   jerlov(i,j)=jerlv0
@@ -1956,7 +1956,7 @@
       n=mod(nstep0+1,2)+1
       call momtum_hs(n,m)
 #endif
-
+      call momtum_init()
 
 #if defined (USE_NUOPC_CESMBETA)
 ! --- Initialization of CICE export
@@ -1971,8 +1971,8 @@
       pcp_fact = 1.0 ! always 1.: no precipiation adjustment
 
 !!Alex  calculation of seas surface slope for export to CICE (NUOPC)
-!$OMP     PARALLEL DO PRIVATE(j,i)
-!$OMP&             SCHEDULE(STATIC,jblk)
+!$OMP     PARALLEL DO PRIVATE(j,i) &
+!$OMP             SCHEDULE(STATIC,jblk)
       do j=1-nbdy,jj+nbdy
         do i=1-nbdy,ii+nbdy
           if (SEA_P) then
@@ -2020,8 +2020,8 @@
       enddo
 !$OMP END PARALLEL DO
 !!Alex calculation of u and v surf for export to CICE
-!$OMP     PARALLEL DO PRIVATE(j,i)
-!$OMP&             SCHEDULE(STATIC,jblk)
+!$OMP     PARALLEL DO PRIVATE(j,i) &
+!$OMP             SCHEDULE(STATIC,jblk)
       do j=1-nbdy,jj+nbdy
         do i=1-nbdy,ii+nbdy
           if (SEA_P) then
@@ -2065,8 +2065,8 @@
 !$OMP END PARALLEL DO
       if (linit) then
 !!Alex initialization of time averaged export fields
-!$OMP     PARALLEL DO PRIVATE(j,i)
-!$OMP&             SCHEDULE(STATIC,jblk)
+!$OMP     PARALLEL DO PRIVATE(j,i) &
+!$OMP             SCHEDULE(STATIC,jblk)
           do j=1-nbdy,jj+nbdy
             do i=1-nbdy,ii+nbdy
               if (SEA_P) then
@@ -2078,8 +2078,8 @@
           enddo
 !$OMP END PARALLEL DO
       else
-!$OMP     PARALLEL DO PRIVATE(j,i)
-!$OMP&             SCHEDULE(STATIC,jblk)
+!$OMP     PARALLEL DO PRIVATE(j,i) &
+!$OMP             SCHEDULE(STATIC,jblk)
           do j=1-nbdy,jj+nbdy
             do i=1-nbdy,ii+nbdy
               if (SEA_P) then
@@ -3671,8 +3671,8 @@
 !!Alex
 !! add mean export field
       inv_cplifq= 1./icefrq
-!$OMP     PARALLEL DO PRIVATE(j,i)
-!$OMP&             SCHEDULE(STATIC,jblk)
+!$OMP     PARALLEL DO PRIVATE(j,i) &
+!$OMP             SCHEDULE(STATIC,jblk)
       do j=1-nbdy,jj+nbdy
         do i=1-nbdy,ii+nbdy
           if (SEA_P) then
@@ -3699,8 +3699,8 @@
 
         sshm(:,:)=srfhgt(:,:)
 !Alex  calculation of seas surface slope for export to CICE (NUOPC)
-!$OMP     PARALLEL DO PRIVATE(j,i)
-!$OMP&             SCHEDULE(STATIC,jblk)
+!$OMP     PARALLEL DO PRIVATE(j,i) &
+!$OMP             SCHEDULE(STATIC,jblk)
         do j=1-nbdy,jj+nbdy
           do i=1-nbdy,ii+nbdy
           if (SEA_P) then
@@ -3748,8 +3748,8 @@
         enddo
 !$OMP END PARALLEL DO
 !!Alex calculation of u and v surf for export to CICE
-!$OMP     PARALLEL DO PRIVATE(j,i)
-!$OMP&             SCHEDULE(STATIC,jblk)
+!$OMP     PARALLEL DO PRIVATE(j,i) &
+!$OMP             SCHEDULE(STATIC,jblk)
         do j=1-nbdy,jj+nbdy
           do i=1-nbdy,ii+nbdy
            if (SEA_P) then
@@ -3767,8 +3767,8 @@
 !$OMP END PARALLEL DO
 
 !!Alex calculation of tmxl,smxl
-!$OMP     PARALLEL DO PRIVATE(j,i)
-!$OMP&             SCHEDULE(STATIC,jblk)
+!$OMP     PARALLEL DO PRIVATE(j,i) &
+!$OMP             SCHEDULE(STATIC,jblk)
         do j=1-nbdy,jj+nbdy
           do i=1-nbdy,ii+nbdy
            if (SEA_P) then
@@ -3797,8 +3797,8 @@
 
 ! --- reset average fields
         ntavg = 0
-!$OMP     PARALLEL DO PRIVATE(j,i)
-!$OMP&             SCHEDULE(STATIC,jblk)
+!$OMP     PARALLEL DO PRIVATE(j,i) &
+!$OMP             SCHEDULE(STATIC,jblk)
         do j=1-nbdy,jj+nbdy
           do i=1-nbdy,ii+nbdy
             if (SEA_P) then

--- a/mod_momtum.F90
+++ b/mod_momtum.F90
@@ -30,10 +30,12 @@
 #endif
         stress,stresx,stresy,dpmx,thkbop, &
         defor1, defor2, & ! deformation components
-        uflux1,vflux1   ! mass fluxes
+        uflux1,vflux1,  &  ! mass fluxes
+        potvor          ! potential vorticity 
+
       contains
 
-      subroutine momtum_init
+      subroutine momtum_init()
 ! Initialization of arrays for momentum equation
       implicit none
 #if defined(RELO)
@@ -42,14 +44,15 @@
               defor2(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy), &
               uflux1(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy), &
               vflux1(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy), &
+              potvor(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy), &
               stress(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy), &
               stresx(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy), &
               stresy(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy), &
               dpmx(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy), &
               thkbop(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy) )
-        call mem_stat_add( 9*(idm+2*nbdy)*(jdm+2*nbdy) )
+        call mem_stat_add( 10*(idm+2*nbdy)*(jdm+2*nbdy) )
 #endif
-        stress = r_init
+        stress = 0. !r_init
         stresx = r_init
         stresy = r_init
         dpmx = r_init
@@ -59,6 +62,7 @@
         defor2 = 0.
         uflux1 = 0.
         vflux1 = 0.
+        potvor = 0.
 
       end  subroutine momtum_init
 
@@ -101,7 +105,6 @@
 !     real*8    wtime1(10),wtime2(20,kdm),wtimes
 !
 # include "stmt_fns.h"
-# include "internal_kappaf.h"
 
 !
 !
@@ -548,6 +551,12 @@
         call xctilr(surty,1,1, 6,6, halo_pv)
       endif !windf
 !
+      return
+!
+      contains
+
+      include 'internal_kappaf.h'
+
       end subroutine momtum_hs
 !
       real function cd_coare(wind,vpmx,airt,sst)

--- a/mod_momtum.F90
+++ b/mod_momtum.F90
@@ -29,7 +29,8 @@
       real, save, dimension(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy) :: &
 #endif
         stress,stresx,stresy,dpmx,thkbop, &
-        defor1, defor2 ! deformation components
+        defor1, defor2, & ! deformation components
+        uflux1,vflux1   ! mass fluxes
       contains
 
       subroutine momtum_init
@@ -38,21 +39,26 @@
 #if defined(RELO)
       allocate( &
               defor1(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy), &
-              defor2(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy)
+              defor2(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy), &
+              uflux1(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy), &
+              vflux1(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy), &
               stress(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy), &
               stresx(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy), &
               stresy(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy), &
-                dpmx(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy), &
+              dpmx(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy), &
               thkbop(1-nbdy:idm+nbdy,1-nbdy:jdm+nbdy) )
-        call mem_stat_add( 7*(idm+2*nbdy)*(jdm+2*nbdy) )
+        call mem_stat_add( 9*(idm+2*nbdy)*(jdm+2*nbdy) )
 #endif
         stress = r_init
         stresx = r_init
         stresy = r_init
         dpmx = r_init
         thkbop = r_init
+! All of these should be zero on land.
         defor1 = 0. 
         defor2 = 0.
+        uflux1 = 0.
+        vflux1 = 0.
 
       end  subroutine momtum_init
 
@@ -3087,7 +3093,7 @@
       logical, parameter :: lpipe_momtum=.false.  !usually .false.
 !
       logical, parameter :: momtum4_orig=.false.  !usually .false.
-      logical, parameter :: momtum4_cfl =.true.   !usually .false.
+      logical, parameter :: momtum4_cfl =.false.   !usually .false.
 !
 #if defined(RELO)
       real, save, allocatable, dimension(:,:) :: &


### PR DESCRIPTION
mod_hycom has some changes of openmp "&" has been moved.
mod_momtum has been modified partly due to differences between SEA_P, SEA_Q and SEA_U in loops where the variable has been calculated and the place where it has been used. Especially when using index i and j +/-1. This has resulted in overflow/underflow errors due to calculations that included points where the value was still equal to the initial value (r_init or huge).
So far vflux1, uflux1, defor1, defor2, stress and potvor has been initialized to zero. This variables has also been  moved to mod_momtum.f90 as they are local variables. This has also disabled double initialization in geopar.F90. In order to initialize these variables a public subroutine momtum_init has been declared. This could potentially include a larger part of the initialization.