### PR TITLE
Fix for overflow

### DIFF
--- a/mod_tsadvc.F90
+++ b/mod_tsadvc.F90
@@ -883,13 +883,21 @@
                     max(0.0,fay(i, jb)) - min(0.0,fay(i, j) )
             if (famax > 0.0) then
               qp = (fqmax-fldlo(i,j)) *fcn(i,j)*scal(i,j)*qdt2
-              rp(i,j) = min(1.0, qp/famax)
+              if (qp > famax) then
+                 rp(i,j) =1.0
+              else
+                  rp(i,j) = min(1.0, qp/famax)
+              endif
             else
               rp(i,j) = 0.0
             endif
             if (famin > 0.0) then
               qm = (fldlo(i,j)-fqmin) *fcn(i,j)*scal(i,j)*qdt2
-              rm(i,j) = min(1.0, qm/famin)
+              if (qm>famin) then
+                 rm(i,j) = 1.0
+              else  
+                 rm(i,j) = min(1.0, qm/famin)
+              endif
             else
               rm(i,j) = 0.0
             endif


### PR DESCRIPTION
famax and famin can be very small numerically compared to qb and qm. Therefore set rm to 1 when qm/qb is larger than famaz/famin. This would most likely eliminate the need for using the minimum function.