### PR TITLE
Correct symbolic link for README

### DIFF
--- a/ALT_CODE/README.src.dimensions
+++ b/ALT_CODE/README.src.dimensions
@@ -1,1 +1,1 @@
-../../README.src/README.src.dimensions
+../README.src/README.src.dimensions


### PR DESCRIPTION
This PR fixes a minor issue with a dangling symbolic link for `ALT_CODE/README.src.dimensions`.